### PR TITLE
Fixed call to closeSync

### DIFF
--- a/lib/fs-copy-file-sync.js
+++ b/lib/fs-copy-file-sync.js
@@ -62,7 +62,7 @@ function copyFileSync(src, dest, flag) {
         fs.writeSync(fdDest, buffer, offset, length, position);
     }
     
-    fs.eloseSync(fdSrc);
+    fs.closeSync(fdSrc);
     fs.closeSync(fdDest);
 }
 


### PR DESCRIPTION
This PR fixes the following error:

    TypeError: fs.eloseSync is not a function